### PR TITLE
Support JSON as manifest file. Minor fixes.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 var program = require('commander');
 var pkg = require('./package.json');
-var proc = require('process');
+var process = require('process');
 var chp = require('child_process');
 var colors = require('colors');
 var fs = require('fs');
@@ -40,13 +40,30 @@ if(utils.obj(program).length < 14){
 
 if(program.file){
   /*parsing file*/
+  if (program.file[0] != '/' && program.file[0] != '~') { // If not an absolute path
+    program.file = process.cwd() + ((process.platform == 'win32')?'\\':'/') + program.file;
+  }
+  if (!fs.existsSync(program.file)) {
+    console.log('File doesn\'t exist');
+    return err();
+  }
+
   data = utils.parser(program.file);
   //cliValidation();
 }
 
 if(!data){
-  var defaultManifest = "orcinus.yml";
-  if(fs.existsSync(defaultManifest)) data = utils.parser(defaultManifest);
+  var defaultManifest = "orcinus";
+  // Favor yaml over json
+  if (fs.existsSync(defaultManifest + '.yml')) {
+    defaultManifest += '.yml';
+  } else if (fs.existsSync(defaultManifest + '.json')) {
+    defaultManifest += '.json';
+  } else {
+    console.log('Default manifest file doesn\'t exist. Expected a *.yml or *.json file.');
+    return err();
+  }
+  data = utils.parser(process.cwd() + ((process.platform == 'win32')?'\\':'/') + defaultManifest);
   //cliValidation();
 }
 

--- a/lib/create.js
+++ b/lib/create.js
@@ -146,7 +146,7 @@ module.exports = {
       // bind
       if(v.type == "bind"){
         if(!v.source || !v.target){
-          console.log("BIND volume is'n valid!");
+          console.log("BIND volume isn't valid!");
           process.exit(0);
         }
         volumes[name[k]] = "type=bind,src="+v.source+",dst="+v.target;

--- a/lib/create.js
+++ b/lib/create.js
@@ -138,7 +138,7 @@ module.exports = {
       // NFS
       if(v.type == "nfs"){
         if(!v.address || !v.source || !v.target){
-          console.log("NFS volume is'n valid!");
+          console.log("NFS volume isn't valid!");
           process.exit(0);
         }
         volumes[name[k]] = "type=volume,volume-opt=o=addr="+v.address+",volume-opt=device=:"+v.source+",volume-opt=type=nfs,source="+name[k]+",target="+v.target;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,15 @@
+var process = require('process');
 var yml = require('yamljs');
+var fileExt = require('file-extension');
 var fs = require('fs');
+
 module.exports = {
   parser : (file)=>{
-    return yml.load(file);
+    // Favor yaml over json
+    if (fileExt(file) === 'yml') {
+      return yml.load(file);
+    }
+    return require(file);
   },
   obj : (val)=>{
     return Object.keys(val);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "base-64": "^0.1.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
+    "file-extension": "^3.1.2",
     "utf8": "^2.1.2",
     "yamljs": "^0.2.8"
   },


### PR DESCRIPTION
Even if docker compose only support yaml, I think the json support still useful for various scenarios :

- A program fetch the JSON from another API endpoint, then use it with orcinus
- It is easier to maintain unit testing ([I still writing for it](https://github.com/herpiko/orcinus/tree/unittesting)) that generate plain JSON which will be consumed by orcinus API